### PR TITLE
[FIX] Revert multiline code block regular expression

### DIFF
--- a/packages/rocketchat-markdown/markdowncode.js
+++ b/packages/rocketchat-markdown/markdowncode.js
@@ -51,7 +51,7 @@ class MarkdownCode {
 			}
 
 			// Separate text in code blocks and non code blocks
-			const msgParts = message.html.split(/(^.*)(```(?:[a-zA-Z]+)?(?:(?:.|\n)*?)```)(.*\n?)$/gm);
+			const msgParts = message.html.split(/^\s*(```(?:[a-zA-Z]+)?(?:(?:.|\n)*?)```)(?:\n)?$/gm);
 
 			for (let index = 0; index < msgParts.length; index++) {
 				// Verify if this part is code


### PR DESCRIPTION
Reverted the multiline code block regular expression to the way it was before commit e2ea4648719fd0ce2dfdbbca6043904c79621b0f.  I believe this introduced the (potentially crippling) bug in Issue #6814.

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #6814

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
